### PR TITLE
Cicognara production should be hosted on production hardware.

### DIFF
--- a/production.hcl
+++ b/production.hcl
@@ -5,7 +5,7 @@ variable "branch_or_sha" {
 job "cicognara-production" {
   region = "global"
   datacenters = ["dc1"]
-  node_pool = "staging"
+  node_pool = "production"
   type = "service"
   group "web" {
     count = 2


### PR DESCRIPTION
The node pool defines which class of hardware is used, which is why the prod site came down for staging maintenance.